### PR TITLE
Refactor/dictionary tooltips

### DIFF
--- a/src/app/feature/components/word/word.component.html
+++ b/src/app/feature/components/word/word.component.html
@@ -30,7 +30,7 @@
                         <div *ngIf="this.wordService.isLearnedWord(word); else add">
                             <button class="wordCard__btn is-disabled">
                                 <svg [innerHTML]="svgService.getLernedIcon()"></svg>
-                                <span class="tooltip">Отметить как изученное</span>
+                                <span class="tooltip">Изученное слово</span>
                             </button>
                         </div>
                         <ng-template #add>
@@ -42,13 +42,13 @@
                         <div *ngIf="this.wordService.isHardWord(word) && this.dictionaryComponent.isHardWordsPage">
                             <button class="wordCard__btn" (click)="this.wordService.addInProgressWord(word)">
                                 <svg [innerHTML]="svgService.getRemoveHardWordIcon()"></svg>
-                                <span class="tooltip">Отметить как сложное</span>
+                                <span class="tooltip">Удалить из сложных</span>
                             </button>
                         </div>
                         <div *ngIf="this.wordService.isHardWord(word) && !this.dictionaryComponent.isHardWordsPage">
                             <button class="wordCard__btn is-disabled">
                                 <svg [innerHTML]="svgService.getHardWordIcon()"></svg>
-                                <span class="tooltip">Отметить как сложное</span>
+                                <span class="tooltip">Сложное слово</span>
                             </button>
                         </div>
                         <div *ngIf="!this.wordService.isHardWord(word)">
@@ -63,6 +63,7 @@
                                 <svg [innerHTML]="svgService.getNoStatisticIcon()"></svg>
                             </ng-template>
                             <span *ngIf="this.wordService.isProgressWord(word.id)" class="tooltip">В процессе изучения</span>
+                            <span *ngIf="!this.wordService.isProgressWord(word.id)" class="tooltip">Новое слово</span>
                         </button>
                     </div>
                 </div>

--- a/src/app/feature/components/word/word.component.html
+++ b/src/app/feature/components/word/word.component.html
@@ -30,30 +30,31 @@
                         <div *ngIf="this.wordService.isLearnedWord(word); else add">
                             <button class="wordCard__btn is-disabled">
                                 <svg [innerHTML]="svgService.getLernedIcon()"></svg>
+                                <span class="tooltip">Отметить как изученное</span>
                             </button>
                         </div>
                         <ng-template #add>
                             <button class="wordCard__btn" (click)="this.wordService.addLearnedWord(word)">
                                 <svg [innerHTML]="svgService.getNotLernedIcon()"></svg>
-                                <span class="tooltip">Mark as Learned</span>
+                                <span class="tooltip">Отметить как изученное</span>
                             </button>
                         </ng-template>
                         <div *ngIf="this.wordService.isHardWord(word) && this.dictionaryComponent.isHardWordsPage">
                             <button class="wordCard__btn" (click)="this.wordService.addInProgressWord(word)">
                                 <svg [innerHTML]="svgService.getRemoveHardWordIcon()"></svg>
-                                <span class="tooltip">Mark as Hard</span>
+                                <span class="tooltip">Отметить как сложное</span>
                             </button>
                         </div>
                         <div *ngIf="this.wordService.isHardWord(word) && !this.dictionaryComponent.isHardWordsPage">
                             <button class="wordCard__btn is-disabled">
                                 <svg [innerHTML]="svgService.getHardWordIcon()"></svg>
-                                <span class="tooltip">Mark as Hard</span>
+                                <span class="tooltip">Отметить как сложное</span>
                             </button>
                         </div>
                         <div *ngIf="!this.wordService.isHardWord(word)">
                             <button class="wordCard__btn" (click)="this.wordService.addHardWord(word)">
                                 <svg [innerHTML]="svgService.getNotHardWordIcon()"></svg>
-                                <span class="tooltip">Mark as Hard</span>
+                                <span class="tooltip">Отметить как сложное</span>
                             </button>
                         </div>
                         <button class="wordCard__btn statistic__btn is-disabled">
@@ -61,7 +62,7 @@
                             <ng-template #notProgressWord>
                                 <svg [innerHTML]="svgService.getNoStatisticIcon()"></svg>
                             </ng-template>
-                            <span class="tooltip">Word in progress</span>
+                            <span *ngIf="this.wordService.isProgressWord(word.id)" class="tooltip">В процессе изучения</span>
                         </button>
                     </div>
                 </div>

--- a/src/app/feature/components/word/word.component.html
+++ b/src/app/feature/components/word/word.component.html
@@ -35,21 +35,25 @@
                         <ng-template #add>
                             <button class="wordCard__btn" (click)="this.wordService.addLearnedWord(word)">
                                 <svg [innerHTML]="svgService.getNotLernedIcon()"></svg>
+                                <span class="tooltip">Mark as Learned</span>
                             </button>
                         </ng-template>
                         <div *ngIf="this.wordService.isHardWord(word) && this.dictionaryComponent.isHardWordsPage">
                             <button class="wordCard__btn" (click)="this.wordService.addInProgressWord(word)">
                                 <svg [innerHTML]="svgService.getRemoveHardWordIcon()"></svg>
+                                <span class="tooltip">Mark as Hard</span>
                             </button>
                         </div>
                         <div *ngIf="this.wordService.isHardWord(word) && !this.dictionaryComponent.isHardWordsPage">
                             <button class="wordCard__btn is-disabled">
                                 <svg [innerHTML]="svgService.getHardWordIcon()"></svg>
+                                <span class="tooltip">Mark as Hard</span>
                             </button>
                         </div>
                         <div *ngIf="!this.wordService.isHardWord(word)">
                             <button class="wordCard__btn" (click)="this.wordService.addHardWord(word)">
                                 <svg [innerHTML]="svgService.getNotHardWordIcon()"></svg>
+                                <span class="tooltip">Mark as Hard</span>
                             </button>
                         </div>
                         <button class="wordCard__btn statistic__btn is-disabled">
@@ -57,6 +61,7 @@
                             <ng-template #notProgressWord>
                                 <svg [innerHTML]="svgService.getNoStatisticIcon()"></svg>
                             </ng-template>
+                            <span class="tooltip">Word in progress</span>
                         </button>
                     </div>
                 </div>

--- a/src/app/feature/components/word/word.component.scss
+++ b/src/app/feature/components/word/word.component.scss
@@ -5,7 +5,6 @@ $prim_dark: #24282c;
 $sec_dark: #3f4850;
 $prim_green: #d3f36b;
 $sec_green: #e6ff96;
-
 %tooltip {
   position: absolute;
 	width: max-content;

--- a/src/app/feature/components/word/word.component.scss
+++ b/src/app/feature/components/word/word.component.scss
@@ -7,18 +7,18 @@ $prim_green: #d3f36b;
 $sec_green: #e6ff96;
 %tooltip {
   position: absolute;
-	width: max-content;
+  width: max-content;
   opacity: 0;
-	padding: 0.75rem 0.875rem;
-	font-size: 0.875rem;
-	text-align: left;
-	z-index: 1;
-	transition: all 0.2s ease-in-out;
-	border-radius: 0.188rem;
-	color: #fff;
+  padding: 0.75rem 0.875rem;
+  font-size: 0.875rem;
+  text-align: left;
+  z-index: 1;
+  transition: all 0.2s ease-in-out;
+  border-radius: 0.188rem;
+  color: #fff;
   top: 50%;
-	left: calc(100% + 0.625rem);
-	transform: translate(0.25rem, -50%);
+  left: calc(100% + 0.625rem);
+  transform: translate(0.25rem, -50%);
   background-color: #24282c;
 }
 
@@ -119,7 +119,7 @@ $sec_green: #e6ff96;
   font-size: 24px;
   line-height: 120%;
   margin: 0 0 10px 0;
-  
+
   i,
   b {
     font-weight: 700;
@@ -152,11 +152,11 @@ $sec_green: #e6ff96;
   position: relative;
 
   &:hover {
-		.tooltip {
-			opacity: 1;
+    .tooltip {
+      opacity: 1;
       transform: translate(0, -50%);
-		}
-	}
+    }
+  }
 
   .tooltip {
     @extend %tooltip;
@@ -199,7 +199,6 @@ $sec_green: #e6ff96;
 }
 
 @media (max-width: 1100px) {
-  
   .wordCard {
     max-width: 360px;
     height: auto;
@@ -265,7 +264,6 @@ $sec_green: #e6ff96;
   }
 }
 @media (max-width: 500px) {
-  
   .wordCard {
     margin: 0 0 30px;
   }

--- a/src/app/feature/components/word/word.component.scss
+++ b/src/app/feature/components/word/word.component.scss
@@ -6,6 +6,23 @@ $sec_dark: #3f4850;
 $prim_green: #d3f36b;
 $sec_green: #e6ff96;
 
+%tooltip {
+  position: absolute;
+	width: max-content;
+  opacity: 0;
+	padding: 0.75rem 0.875rem;
+	font-size: 0.875rem;
+	text-align: left;
+	z-index: 1;
+	transition: all 0.2s ease-in-out;
+	border-radius: 0.188rem;
+	color: #fff;
+  top: 50%;
+	left: calc(100% + 0.625rem);
+	transform: translate(0.25rem, -50%);
+  background-color: #24282c;
+}
+
 .wordCard {
   width: 100%;
   min-height: 400px;
@@ -133,6 +150,18 @@ $sec_green: #e6ff96;
   cursor: pointer;
   background: transparent;
   margin-bottom: 15px;
+  position: relative;
+
+  &:hover {
+		.tooltip {
+			opacity: 1;
+      transform: translate(0, -50%);
+		}
+	}
+
+  .tooltip {
+    @extend %tooltip;
+  }
 }
 
 .wordCard__btn:hover svg {


### PR DESCRIPTION
added tooltips for word's buttons via SCSS
![image](https://user-images.githubusercontent.com/94010184/188671456-5ee2924d-8978-44ba-8834-3ec0111fb1b5.png)
![image](https://user-images.githubusercontent.com/94010184/188671476-531eda84-8d2a-4ee7-96b4-65bb54db9cf2.png)

if word is in learn progress we can see toolltip here too
![image](https://user-images.githubusercontent.com/94010184/188671609-554ace88-963a-4506-a0f9-d7125177d65b.png)
